### PR TITLE
Fix typo in task description

### DIFF
--- a/src/engine/task.ts
+++ b/src/engine/task.ts
@@ -199,7 +199,7 @@ export const OBSERVE_PATROL_ROUTES: Task = {
   name: "Observe Patrol Routes",
   shortName: "OBS_PTRL",
   baseCost: () => 3500,
-  description: "Learn the patrol routes of the Presever cleanup crew.",
+  description: "Learn the patrol routes of the Preserver cleanup crew.",
   flavor:
     "Tactical planning substrate suggests attacking during moments of isolation.",
   required: { progress: { ruinsExploration: 15 } },


### PR DESCRIPTION
I just finished a playthrough of this game and noticed this one little typo. I know this isn't under active development but I thought I might as well throw a quick patch your way, and you can do with it as you please.

While I'm here I also want to say that I enjoyed playing wrtsc! There's some intriguing storytelling backing up the gameplay loop that makes me want to know what happens next. I appreciate that you put this out into the world, even in its beta state. Thanks!